### PR TITLE
Fix show playlist in music OSD

### DIFF
--- a/720p/MusicOSD.xml
+++ b/720p/MusicOSD.xml
@@ -102,6 +102,7 @@
 					<width>52</width>
 					<texturefocus>osd/osd_button_playlist_fo.png</texturefocus>
 					<texturenofocus>osd/osd_button_playlist_nf.png</texturenofocus>
+					<onclick>Dialog.Close(musicosd)</onclick>
 					<onclick>ActivateWindow(musicplaylist)</onclick>
 				</control>
 				<control type="button" id="16">

--- a/720p/VideoOSD.xml
+++ b/720p/VideoOSD.xml
@@ -46,6 +46,7 @@
 					<width>60</width>
 					<texturefocus>osd/osd_button_playlist_fo.png</texturefocus>
 					<texturenofocus>osd/osd_button_playlist_nf.png</texturenofocus>
+					<onclick>Dialog.Close(videoosd)</onclick>
 					<onclick>ActivateWindow(videoplaylist)</onclick>
 				</control>
 				<control type="button" id="12">


### PR DESCRIPTION
The current code would not open the playlist window when the playlist button was selected in the music and video  OSDs. Modal dialogs must be closed before a new window can be opened. Adding the line to close the dialog allows the playlist window to open.